### PR TITLE
Support for Firmware 1.75 features 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ env/
 lmnotify.egg-info/
 dist/
 build/
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -58,12 +58,6 @@ As simple example, let's send a "hellow world" message with an icon to the LaMet
     # use first device to do some tests
     lmn.set_device(devices[0])
 
-    # obtain all registered devices from the LaMetric cloud
-    devices = lmn.get_devices()
-
-    # select the first device for interaction
-    lmn.set_device(devices[0])
-
     # prepare a simple frame with an icon and some text
     sf = SimpleFrame("i210", "Hello World!")
 

--- a/examples/alarmclock.py
+++ b/examples/alarmclock.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from lmnotify import LaMetricManager
+
+
+def main():
+    lmn = LaMetricManager()
+
+    # get devices
+    devices = lmn.get_devices()
+
+    # use first device to do some tests
+    lmn.set_device(devices[0])
+
+    # time for alarm to go off
+    wake_me = "14:00"
+
+    # set alarm and enable alarm with radio
+    lmn.alarm_set(wake_me, wake_with_radio=True)
+
+    print("Don't forget to turn the alarm off")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -13,12 +13,6 @@ def main():
     # use first device to do some tests
     lmn.set_device(devices[0])
 
-    # obtain all registered devices from the LaMetric cloud
-    devices = lmn.get_devices()
-
-    # select the first device for interaction
-    lmn.set_device(devices[0])
-
     # prepare a simple frame with an icon and some text
     sf = SimpleFrame("i210", "Hello World!")
 

--- a/examples/radio.py
+++ b/examples/radio.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from lmnotify import LaMetricManager
+import time
+
+
+def main():
+    lmn = LaMetricManager()
+
+    # get devices
+    devices = lmn.get_devices()
+
+    # use first device to do some tests
+    lmn.set_device(devices[0])
+
+    # turn on radio
+    lmn.radio_play()
+
+    # listen for a few seconds
+    time.sleep(5)
+
+    # switch channel
+    lmn.radio_next()
+
+    # listen for again for a few seconds
+    time.sleep(5)
+
+    # turn radio off
+    lmn.radio_stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/lmnotify/const.py
+++ b/lmnotify/const.py
@@ -71,6 +71,18 @@ DEVICE_URLS = {
     "get_apps_list": (
         "GET", "https://%s:4343/api/v2/device/apps/"
     ),
+    # Switch to next app
+    "switch_to_next_app": (
+        "PUT", "https://%s:4343/api/v2/device/apps/next"
+    ),
+    # Switch to previous app
+    "switch_to_prev_app": (
+        "PUT", "https://%s:4343/api/v2/device/apps/prev"
+    ),
+    # execute an action
+    "do_action": (
+        "POST", "https://%s:4343/api/v2/device/apps/%s/widgets/%s/action"
+    )
 }
 
 

--- a/lmnotify/const.py
+++ b/lmnotify/const.py
@@ -71,6 +71,10 @@ DEVICE_URLS = {
     "get_apps_list": (
         "GET", "https://%s:4343/api/v2/device/apps/"
     ),
+    # Switch to specific app
+    "switch_to_app": (
+        "PUT", "https://%s:4343/api/v2/device/apps/%s/widgets/%s/activate"
+    ),
     # Switch to next app
     "switch_to_next_app": (
         "PUT", "https://%s:4343/api/v2/device/apps/next"

--- a/lmnotify/models.py
+++ b/lmnotify/models.py
@@ -4,18 +4,29 @@ class AppModel(object):
     """
     class representing a installed app on the LaMetric
     """
-    def __init__(self, app_id, data):
-        self.app_id = app_id
-        self.properties = dict.fromkeys(AVAILABLE_APP_PROPERTIES)
-        self.set_properties(data)
+    def __init__(self, data):
+        self.actions = {}
+        self.package = ''
+        self.vendor = ''
+        self.version = ''
+        self.version_code = ''
+        self.widgets = ''
         
-    def set_properties(self, data):
-        for property in self.properties.keys():
-            if property in data.keys():
-                self.properties[property] = data[property]
+        self._set_properties(data)
                 
-    def get_properties(self):
-        return self.properties
+    def _set_properties(self, data):
+        if 'actions' in data.keys():
+            self.actions = data['actions']
+        if 'package' in data.keys():
+            self.package = data['package']
+        if 'vendor' in data.keys():
+            self.vendor = data['vendor']
+        if 'version' in data.keys():
+            self.version = data['version']
+        if 'version_code' in data.keys():
+            self.version_code = data['version_code']
+        if 'widgets' in data.keys():
+            self.widgets = data['widgets']
 
 
 class Frame(object):

--- a/lmnotify/models.py
+++ b/lmnotify/models.py
@@ -1,7 +1,6 @@
 from .const import SOUND_IDS, ALARM_IDS
 
 
-
 class AppModel(object):
     """
     class representing a installed app on the LaMetric

--- a/lmnotify/models.py
+++ b/lmnotify/models.py
@@ -1,4 +1,5 @@
-from .const import SOUND_IDS, ALARM_IDS, AVAILABLE_APP_PROPERTIES
+from .const import SOUND_IDS, ALARM_IDS
+
 
 class AppModel(object):
     """
@@ -120,7 +121,9 @@ class Model(object):
     """
     a model can consist of multiple frames and a sound
     """
-    def __init__(self, frames=[], cycles=1, sound=None):
+    def __init__(self, frames=None, cycles=1, sound=None):
+        if frames is None:
+            frames = []
         assert(cycles >= 0)
         assert(sound is None or isinstance(sound, Sound))
 


### PR DESCRIPTION
- switching apps
- play/pause radio
- switch radio channels
- start/pause/reset countdown and stopwatch
- enable/disable/set alarm clock
- examples for alarm clock and radio

Note: There is a bug in the API that doesn't allow to go to the previous radio channel. You can only use the next method at the moment.