### PR TITLE
Auth without config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Config
 
 The LaMetric Time can only be accessed by authorized applications. Therefore, each application that wants to access the LaMetric time needs to be registered at the `LaMetric Developer <https://developer.lametric.com>`_ webpage. Sign Up and login to the developer webpage. Click the **Create** button in the upper right corner, then select **Notification App** and click **Create** again. Enter an app name, a description and a redirect URL. Finally, click **Save** to create the application. For the newly created app you will obtain a **client id** and a **client secret** that is required in the following.
 
-The obtained credentials must be stored in the ``~/.lmconfig`` config file so that ``lmnotify`` can access it.
+The obtained credentials can be stored in the ``~/.lmconfig`` config file so that ``lmnotify`` can access it. You can also pass the two
+parameters directly into the constructor.
 
 ::
 

--- a/lmnotify/lmnotify.py
+++ b/lmnotify/lmnotify.py
@@ -22,7 +22,7 @@ class LaMetricManager(object):
     simple python class that allows the sending of notification
     messages to the LaMetric (https://www.lametric.com)
     """
-    def __init__(self, config_file=CONFIG_FILE):
+    def __init__(self, config_file=CONFIG_FILE, client_id=None, client_secret=None):
         # set current device to none
         self.dev = None
 
@@ -36,8 +36,13 @@ class LaMetricManager(object):
         # list of installed apps
         self.available_apps = []
 
-        # load the config i.e. the LaMetric API details
-        self.load_config(os.path.expanduser(config_file))
+        # if client_id or client_secret are not passed into the constructor
+        if client_id is None or client_secret is None:
+            # load the config i.e. the LaMetric API details
+            self.load_config(os.path.expanduser(config_file))
+        else:
+            self.client_id = client_id
+            self.client_secret = client_secret
 
         # create oauth2 session that is required to access the cloud
         self.oauth = OAuth2Session(


### PR DESCRIPTION
client_id and client_secret can be passed directly into the constructor.